### PR TITLE
kai.c: include process.h for watcom to silence missing prototype warning

### DIFF
--- a/kai.c
+++ b/kai.c
@@ -41,6 +41,7 @@
 
 #ifdef __WATCOMC__
 #include <alloca.h>
+#include <process.h>
 #endif
 
 #define SAMPLESTOBYTES( s, ks ) (( s ) * (( ks ).ulBitsPerSample >> 3 ) * \


### PR DESCRIPTION
kai.c(651): Warning! W131: No prototype found for function '_beginthread'